### PR TITLE
LadderTrackerLauncher

### DIFF
--- a/LadderTracker.sln
+++ b/LadderTracker.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31005.135
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LadderTracker", "LadderTracker/LadderTracker.csproj", "{18E6D511-1681-4839-B7E7-A517B9173CC5}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LadderTracker", "LadderTracker\LadderTracker.csproj", "{18E6D511-1681-4839-B7E7-A517B9173CC5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LadderTrackerLauncher", "LadderTrackerLauncher\LadderTrackerLauncher.csproj", "{2EB971D9-EE8B-417B-A007-18BF5A2ECB02}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{18E6D511-1681-4839-B7E7-A517B9173CC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{18E6D511-1681-4839-B7E7-A517B9173CC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{18E6D511-1681-4839-B7E7-A517B9173CC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EB971D9-EE8B-417B-A007-18BF5A2ECB02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EB971D9-EE8B-417B-A007-18BF5A2ECB02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EB971D9-EE8B-417B-A007-18BF5A2ECB02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EB971D9-EE8B-417B-A007-18BF5A2ECB02}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LadderTrackerLauncher/App.config
+++ b/LadderTrackerLauncher/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    </startup>
+</configuration>

--- a/LadderTrackerLauncher/FileUtils.cs
+++ b/LadderTrackerLauncher/FileUtils.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace LadderTrackerLauncher
+{
+    internal class FileUtils
+    {
+        const string FOLDER_NAME = "LadderTrackerInstall";
+
+        public static string GetInstalledVersion()
+        {
+            return new DirectoryInfo(GetInstallDirectory())
+                .GetFiles()
+                .FirstOrDefault(f => f.FullName.Contains(".zip"))?.Name.Replace(".zip", "");
+        }
+
+        public static void ClearInstallDirectory(List<string> exceptions)
+        {
+            foreach (FileInfo file in new DirectoryInfo(GetInstallDirectory()).GetFiles())
+            {
+                if(exceptions == null || !exceptions.Contains(file.Name))
+                    file.Delete();
+            }
+        }
+
+        public static void Unzip(string fileName)
+        {
+            string fileNameWithExtention = (fileName.EndsWith(".zip")) ? fileName : fileName + ".zip";
+            ZipArchive zip = new ZipArchive(new StreamReader(Path.Combine(GetInstallDirectory(), fileNameWithExtention)).BaseStream);
+            zip.ExtractToDirectory(GetInstallDirectory());
+        }
+
+        public static string GetInstallDirectory()
+        {
+            //CreateDirectory will do nothing if it already exists
+            Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), FOLDER_NAME));
+            return Path.Combine(Directory.GetCurrentDirectory(), FOLDER_NAME);
+        }
+    }
+}

--- a/LadderTrackerLauncher/GithubHttpClient.cs
+++ b/LadderTrackerLauncher/GithubHttpClient.cs
@@ -1,0 +1,64 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace LadderTrackerLauncher
+{
+    internal class GithubHttpClient
+    {
+        public static async Task<string> GetLatestVersion()
+        {
+            HttpResponseMessage response = null;
+
+            try
+            {
+                HttpClient client = new HttpClient();
+                HttpRequestMessage request = new HttpRequestMessage()
+                {
+                    RequestUri = new Uri("https://api.github.com/repos/jgayewu/LadderTracker/releases/latest"),
+                    Method = HttpMethod.Get,
+                };
+                request.Headers.Add("User-Agent", "request");
+
+                response = await client.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+                string jsonResponse = await response.Content.ReadAsStringAsync();
+                JObject jObject = JObject.Parse(jsonResponse);
+                return jObject["tag_name"].ToString();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("\nException Caught!");
+                Console.WriteLine("Message :{0} ", e.Message);
+
+                throw;
+            }
+            finally
+            {
+                if (response != null)
+                    response.Dispose();
+            }
+        }
+
+        public static void DownloadVersion(string version, string downloadDirectory)
+        {
+            try
+            {
+                WebClient webClient = new WebClient();
+                webClient.Headers.Add("Accept: text/html, application/xhtml+xml, */*");
+                webClient.Headers.Add("User-Agent: request");
+                webClient.DownloadFile(new Uri($"https://github.com/jgayewu/LadderTracker/releases/latest/download/{version}.zip"), Path.Combine(downloadDirectory, $"{version}.zip"));
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine("\nException Caught!");
+                Console.WriteLine("Message :{0} ", e.Message);
+
+                throw;
+            }
+        }
+    }
+}

--- a/LadderTrackerLauncher/LadderTrackerLauncher.csproj
+++ b/LadderTrackerLauncher/LadderTrackerLauncher.csproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2EB971D9-EE8B-417B-A007-18BF5A2ECB02}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>LadderTrackerLauncher</RootNamespace>
+    <AssemblyName>LadderTrackerLauncher</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FileUtils.cs" />
+    <Compile Include="GithubHttpClient.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VersionManager.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/LadderTrackerLauncher/Program.cs
+++ b/LadderTrackerLauncher/Program.cs
@@ -1,0 +1,10 @@
+﻿namespace LadderTrackerLauncher
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            VersionManager.UpdateAndLaunch();
+        }
+    }
+}

--- a/LadderTrackerLauncher/Properties/AssemblyInfo.cs
+++ b/LadderTrackerLauncher/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("LadderTrackerLauncher")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LadderTrackerLauncher")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2eb971d9-ee8b-417b-a007-18bf5a2ecb02")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/LadderTrackerLauncher/VersionManager.cs
+++ b/LadderTrackerLauncher/VersionManager.cs
@@ -1,18 +1,14 @@
-﻿using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Net;
-using System.Net.Http;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace LadderTrackerLauncher
 {
     internal class VersionManager
     {
         const string EXE_NAME = "LadderTracker.exe";
+        private static List<string> FILE_DELETION_EXCEPTIONS = new List<string>(){ "LadderTrackerDB.db" };
 
         public static void UpdateAndLaunch()
         {
@@ -21,7 +17,7 @@ namespace LadderTrackerLauncher
 
             if(IsNewerVersion(currentVersion, latestVersion))
             {
-                FileUtils.ClearInstallDirectory(new List<string>() { "LadderTrackerDB.db" });
+                FileUtils.ClearInstallDirectory(FILE_DELETION_EXCEPTIONS);
                 GithubHttpClient.DownloadVersion(latestVersion, FileUtils.GetInstallDirectory());
                 FileUtils.Unzip(latestVersion);
             }
@@ -29,24 +25,34 @@ namespace LadderTrackerLauncher
             Process.Start(Path.Combine(FileUtils.GetInstallDirectory(), EXE_NAME));
         }
 
-        static bool IsNewerVersion(string originalVersion, string newVersion)
+        static bool IsNewerVersion(string originalVersion, string incomingVersion)
         {
             if (originalVersion == null)
                 return true;
 
-            if (originalVersion == newVersion)
+            if (originalVersion == incomingVersion)
                 return false;
 
+            //regex magic to pull just the x.x.x numbering
             string origExtracted = Regex.Match(originalVersion, @"(\d+\.\d+\.\d+)").Groups[0].Value;
-            string newExtracted = Regex.Match(newVersion, @"(\d+\.\d+\.\d+)").Groups[0].Value;
+            string newExtracted = Regex.Match(incomingVersion, @"(\d+\.\d+\.\d+)").Groups[0].Value;
 
-            string[] firstVersions = origExtracted.Split('.');
-            string[] secondVersions = newExtracted.Split('.');
+            string[] originalVersionNumbers = origExtracted.Split('.');
+            string[] incomingVersionNumbers = newExtracted.Split('.');
 
-            int firstNumerical = (int.Parse(firstVersions[0]) * 100) + (int.Parse(firstVersions[1]) * 10) + int.Parse(firstVersions[2]);
-            int secondNumerical = (int.Parse(secondVersions[0]) * 100) + (int.Parse(secondVersions[1]) * 10) + int.Parse(secondVersions[2]);
+            //major
+            if (int.Parse(originalVersionNumbers[0]) < int.Parse(incomingVersionNumbers[0]))
+                return true;
 
-            return firstNumerical < secondNumerical;
+            //minor
+            if (int.Parse(originalVersionNumbers[1]) < int.Parse(incomingVersionNumbers[1]))
+                return true;
+
+            //revision
+            if (int.Parse(originalVersionNumbers[2]) < int.Parse(incomingVersionNumbers[2]))
+                return true;
+
+            return false;
         }
     }
 }

--- a/LadderTrackerLauncher/VersionManager.cs
+++ b/LadderTrackerLauncher/VersionManager.cs
@@ -1,0 +1,52 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace LadderTrackerLauncher
+{
+    internal class VersionManager
+    {
+        const string EXE_NAME = "LadderTracker.exe";
+
+        public static void UpdateAndLaunch()
+        {
+            string currentVersion = FileUtils.GetInstalledVersion();
+            string latestVersion = GithubHttpClient.GetLatestVersion().Result;
+
+            if(IsNewerVersion(currentVersion, latestVersion))
+            {
+                FileUtils.ClearInstallDirectory(new List<string>() { "LadderTrackerDB.db" });
+                GithubHttpClient.DownloadVersion(latestVersion, FileUtils.GetInstallDirectory());
+                FileUtils.Unzip(latestVersion);
+            }
+
+            Process.Start(Path.Combine(FileUtils.GetInstallDirectory(), EXE_NAME));
+        }
+
+        static bool IsNewerVersion(string originalVersion, string newVersion)
+        {
+            if (originalVersion == null)
+                return true;
+
+            if (originalVersion == newVersion)
+                return false;
+
+            string origExtracted = Regex.Match(originalVersion, @"(\d+\.\d+\.\d+)").Groups[0].Value;
+            string newExtracted = Regex.Match(newVersion, @"(\d+\.\d+\.\d+)").Groups[0].Value;
+
+            string[] firstVersions = origExtracted.Split('.');
+            string[] secondVersions = newExtracted.Split('.');
+
+            int firstNumerical = (int.Parse(firstVersions[0]) * 100) + (int.Parse(firstVersions[1]) * 10) + int.Parse(firstVersions[2]);
+            int secondNumerical = (int.Parse(secondVersions[0]) * 100) + (int.Parse(secondVersions[1]) * 10) + int.Parse(secondVersions[2]);
+
+            return firstNumerical < secondNumerical;
+        }
+    }
+}

--- a/LadderTrackerLauncher/packages.config
+++ b/LadderTrackerLauncher/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net472" />
+  <package id="System.IO" version="4.3.0" targetFramework="net472" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net472" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
Added Launcher project.

It will reach out to github's latest release and compare it with the version that is currently installed.
If there is no version, it will just pull the latest and use it.
It tracks the version by keeping the release's zip file, so all releases need to be zipped up and named with the following x.x.x structure. 

Once the version is downloaded (or determined that no download is needed) it will launch the LadderTracker application.